### PR TITLE
feat: update respondent position on map as they move towards request.

### DIFF
--- a/src/app/pages/respondant-pages/respondent-view-request-on-map/respondent-view-request-on-map.page.ts
+++ b/src/app/pages/respondant-pages/respondent-view-request-on-map/respondent-view-request-on-map.page.ts
@@ -43,6 +43,31 @@ export class RespondentViewRequestOnMapPage implements OnInit {
       message: 'Checking current location...'
     }).then((overlay) => {
       overlay.present();
+      //call the watch position function
+      const id = Geolocation.watchPosition({ enableHighAccuracy: true, timeout: 10000 }, (position, err) => {
+        // Geolocation.clearWatch({id});
+        overlay.dismiss();
+        this.latitude = position.coords.latitude;
+        this.longitude = position.coords.longitude;
+        const currentLocation = {
+          lat : this.latitude,
+          lng : this.longitude
+        };
+        this.map.viewRequestOnMap(currentLocation,this.coord);
+        this.map.changeMarker(this.latitude, this.longitude);
+        const data = {
+          latitude: this.latitude,
+          longitude: this.longitude
+        };
+        if (err) {
+          console.log(err);
+          overlay.dismiss();
+          return;
+        }
+
+      });
+      
+      /**
       Geolocation.getCurrentPosition().then((position) => {
         overlay.dismiss();
         this.latitude = position.coords.latitude;
@@ -68,6 +93,7 @@ export class RespondentViewRequestOnMapPage implements OnInit {
         console.log(err);
         overlay.dismiss();
       });
+      */
     });
   }
 


### PR DESCRIPTION
## Description
Uses watchPosition() API to get auto update the respondent's position on the map as they travel towards the request.

Fixes #100 

## How Has This Been Tested?
Tested via browser

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
