### PR TITLE
Direction service failure after first init

### DIFF
--- a/src/app/components/google-map/google-map.component.ts
+++ b/src/app/components/google-map/google-map.component.ts
@@ -218,7 +218,7 @@ export class GoogleMapComponent {
     var markerInfo;
     console.log("Auth Details", markers);
     markers.forEach((marker) => {
-      var image = 'http://maps.google.com/mapfiles/kml/shapes/caution.png';
+      var image = 'http://maps.google.com/mapfiles/kml/pal3/icon33.png';
       markerInfo = new google.maps.Marker({
         position: new google.maps.LatLng(marker['location']['lat'], marker['location']['lng']),
         map: this.map,

--- a/src/app/pages/victim-pages/view-dangers/view-dangers.page.ts
+++ b/src/app/pages/victim-pages/view-dangers/view-dangers.page.ts
@@ -33,6 +33,10 @@ export class ViewDangersPage implements OnInit {
 
   private region: any = {};
 
+  private direction: boolean = false;
+
+  directionsDisplay: any ;
+
   address: Object;
   formattedAddress: string;
 
@@ -98,9 +102,9 @@ export class ViewDangersPage implements OnInit {
     .then(result=>{
       //console.log(result, "result");
       Geolocation.getCurrentPosition({ enableHighAccuracy: true, timeout: 10000 }).then((current_pos) => {
-        //remove any previously drawn lines.
-        if(typeof(this.region.geodesic) != 'undefined'){
-          this.region.setMap(null);
+        //remove any previously drawn directional lines.
+        if(this.direction == true){
+          this.directionsDisplay.setMap(null);
           this.map.map.setCenter(new google.maps.LatLng(current_pos.coords.latitude, current_pos.coords.longitude));
         }
         //destination coordinates from the geocoding 
@@ -112,6 +116,7 @@ export class ViewDangersPage implements OnInit {
           //destination
           {lat: this.destinationLatLng.lat, lng: this.destinationLatLng.lng}
         ];
+        /**
         this.region = new google.maps.Polyline({
           path: coords, 
           geodesic: true,
@@ -121,6 +126,30 @@ export class ViewDangersPage implements OnInit {
         });
 
         this.region.setMap(this.map.map);
+         */
+
+        this.directionsDisplay = new google.maps.DirectionsRenderer();
+        this.directionsDisplay.setMap(this.map.map);
+        console.log(this.directionsDisplay);
+        const start = new google.maps.LatLng(current_pos.coords.latitude, current_pos.coords.longitude);
+        const end = new google.maps.LatLng(this.destinationLatLng.lat, this.destinationLatLng.lng);
+        const directionsService = new google.maps.DirectionsService();
+        //we declare a variable that because 
+        //"this" becomes undefined inside the route callback
+        var that = this ;
+        directionsService.route(
+          {
+            origin: start,
+            destination: end,
+            travelMode: google.maps.TravelMode.DRIVING
+          },
+          function (response, status) {
+            if (status === 'OK') {
+              that.directionsDisplay.setDirections(response);
+              //set a variable to tell that directions service has been initiated
+              that.direction = true ; 
+            }
+          });
 
       }, (err) => {
         console.log(err);


### PR DESCRIPTION
## Description
Direction service works on first initialization but when a user tries to request the service a second time, a failure occurs such that the initial instance of the service remains on the map causing confusion. This fix uses some old tricks to solve the problem and destroy an instance of the service if a new instance is initiated by the user.

Fixes #105 

## How Has This Been Tested?
Tested via browser

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
